### PR TITLE
Changed Ipv4-compatible to Ipv4-mapped addresses

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,10 +53,10 @@ pub fn ip(name: &str, net: IpNetwork) -> Result<IpAddr> {
                 return Err(Error::PrefixTooBig(net));
             }
             let prefix = IP6_PREFIX - IP4_PREFIX + net4.prefix();
-            let net6 = format!("::{}/{prefix}", net4.ip()).parse::<Ipv6Network>()?;
+            let net6 = format!("::ffff:{}/{prefix}", net4.ip()).parse::<Ipv6Network>()?;
             let ipv6_addr = ip6(name, net6)?.to_string();
             let ip_addr = ipv6_addr
-                .strip_prefix("::")
+                .strip_prefix("::ffff:")
                 // This error should never happen but I'm not a fan of panicking in libraries
                 .ok_or_else(|| Error::InvalidIpNetwork(format!("[BUG] the generated IPv6 address `{ipv6_addr}` does not start with the expected prefix `::`")))?
                 .parse()


### PR DESCRIPTION
## Background

This crate states that it supports the use of Ipv4 CIDR notation when defining a range for the IP generator to use. However, during my tests using it I did not find that to be the case. Rather, I got the following error:
```
Error: InvalidIpNetwork("[BUG] failed to parse the generated IP address `a83:6304` as IPv4")
```

Furthermore, the test currently fail in `lib.rs`

## Changes

After doing some debugging within the crate itself, I found that when converting from Ipv4 to Ipv6, Ipv4-compatible Ipv6 addresses were used. This type of address "was defined to assist in the IPv6 transition" and is now deprecated as of [RFC 4291](https://datatracker.ietf.org/doc/html/rfc4291#section-2.5.5.1). Instead of prepending a `::`, in the case of the Ipv4-compatible address, `ip()` should prepend `::fff:` (and likewise strip). 

## Conclusion

This fixes the issues I encountered when trying to generate Ipv4 addresses using this crate and restores the tests in `lib.rs` to working order.

