### PR TITLE
Reworked Crate to Hash Bit Instead of Hex Characters

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,8 @@ pub enum Error {
     InvalidIpNetwork(String),
     /// Network address provided is already a full IP address
     PrefixTooBig(crate::IpNetwork),
+    /// Failed to parse string
+    ParseFailed(String),
 }
 
 impl error::Error for Error {}
@@ -21,7 +23,7 @@ impl error::Error for Error {}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Error::InvalidIpNetwork(error) => write!(f, "{}", error),
+            Error::InvalidIpNetwork(error) | Error::ParseFailed(error) => write!(f, "{}", error),
             Error::PrefixTooBig(crate::IpNetwork(net)) => write!(
                 f,
                 "{}/{} is already a full IP address",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ fn ip6(name: &str, net: Ipv6Network) -> Result<Ipv6Addr> {
     // Convert the address to a u128
     let network_hash = net.ip().to_bits();
 
-    // The number of bit characters we need to generate
+    // The number of bits we need to generate
     //
     // * An IPv6 address has a total number of 128 bits.
     // * Subtracting the network prefix length from the total in an IP address

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,32 +54,9 @@ pub fn ip(name: &str, net: IpNetwork) -> Result<IpAddr> {
                 let net6 = Ipv6Network::new(net4.ip().to_ipv6_mapped(), prefix)?;
                 Ok(IpAddr::V4(ip6(name, net6)?.to_ipv4_mapped().unwrap()))
             }
-<<<<<<< HEAD
             Equal => Ok(IpAddr::V4(net4.ip())),
             Greater => Err(Error::PrefixTooBig(net)),
         },
-=======
-            ip6(name, net6).map(IpAddr::V6)
-        }
-        // handle IPv4 address
-        ipnetwork::IpNetwork::V4(net4) => {
-            if net4.prefix() == IP4_PREFIX {
-                return Err(Error::PrefixTooBig(net));
-            }
-            let prefix = IP6_PREFIX - IP4_PREFIX + net4.prefix();
-            let net6 = format!("::ffff:{}/{prefix}", net4.ip()).parse::<Ipv6Network>()?;
-            let ipv6_addr = ip6(name, net6)?.to_string();
-            let ip_addr = ipv6_addr
-                .strip_prefix("::ffff:")
-                // This error should never happen but I'm not a fan of panicking in libraries
-                .ok_or_else(|| Error::InvalidIpNetwork(format!("[BUG] the generated IPv6 address `{ipv6_addr}` does not start with the expected prefix `::`")))?
-                .parse()
-                // This error should never happen but I'm not a fan of panicking in libraries
-                .map_err(|_| Error::InvalidIpNetwork(format!("[BUG] failed to parse the generated IP address `{}` as IPv4", ipv6_addr.trim_start_matches(':'))))
-                ?;
-            Ok(IpAddr::V4(ip_addr))
-        }
->>>>>>> main
     }
 }
 


### PR DESCRIPTION
## Introduction

I have been trying to use this neat crate as an IP generator in a project of mine and have run into a couple problems:
- Ipv4 compatibility is not functional (addressed in #3)
- "Uneven" subnet masks are note applied properly (as documented in #4 and [this issue](https://github.com/ipgen/spec/issues/1))

The first of these has been resolved in #3 as said, on which this PR depends. The rest of this PR is dedicated to the latter problem.

## Changes

Instead of using a hashing system that relies on masking out hex characters (which has its problems as documented in #4), I have ventured to convert all such use of hex characters to bit characters instead.

For example, instead of preserving the first 2 hex characters of an address that has a prefix length of 8, the first 8 bit characters are preserved. 

This provides a much more accurate system of generation that I hope improves the popularity and usability of this crate.